### PR TITLE
keepalive

### DIFF
--- a/.github/workflows/BurgerClaimer.yml
+++ b/.github/workflows/BurgerClaimer.yml
@@ -21,3 +21,12 @@ jobs:
         WIF: ${{ secrets.TEEWIF }}
         RPC: https://n3seed2.ngd.network:10332
         THREASHOLD: 17179869184
+    - name: action-keepalive-check
+      run: |
+        if (( $(git --no-pager log -1 --format=%ct) < $(date --date "last month" +%s) )); then
+          git config --global user.email bot@neoburger.io
+          git config --global user.name bot
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/neoburger/TEE.git
+          git commit --allow-empty -m "Dummy commit created to keep the repository active..."
+          git push origin HEAD
+        fi


### PR DESCRIPTION
> see [ref](https://github.com/gautamkrishnar/keepalive-workflow)

### Why
GitHub will suspend the scheduled trigger for GitHub action workflows if there is no commit in the repository for the past 60 days. The cron based triggers won't run unless a new commit is made. It shows the message "This scheduled workflow is disabled because there hasn't been activity in this repository for at least 60 days" under the cronjob triggered action.

![preview](https://user-images.githubusercontent.com/8397274/105174930-4303e100-5b49-11eb-90ed-95a55697582f.png)

### What
This workflow will automatically create a dummy commit in your repo if the last commit in your repo is 30 days (default) ago.
This will keep the cronjob trigger active so that it will run indefinitely without getting suspended by GitHub for inactivity.
